### PR TITLE
Fix site footer feedback link

### DIFF
--- a/themes/jaxplays/layouts/partials/site-footer.html
+++ b/themes/jaxplays/layouts/partials/site-footer.html
@@ -4,7 +4,7 @@
     <div><a class="f4 fw4 hover-white no-underline white-70 dn dib pv2 ph3" href="{{ .Site.Home.Permalink }}">
       &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ now.Format "2006"}} {{ end }}
     </a>
-    <a class="f4 fw4 hover-white no-underline white-70 dn dib pv2 ph3" data-canny-link href="https://jaxplays.canny.io" />
+    <a class="f4 fw4 hover-white no-underline white-70 dn dib pv2 ph3" data-canny-link href="https://jaxplays.canny.io">
       Give feedback
     </a>
     </div>


### PR DESCRIPTION
## Summary
- fix HTML for feedback link in site footer

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f08b5459c83249cb20baa874805f7