### PR TITLE
Add theatre past productions pagination

### DIFF
--- a/themes/jaxplays/layouts/theatres/single.html
+++ b/themes/jaxplays/layouts/theatres/single.html
@@ -113,6 +113,7 @@
     {{ $currentlyOnStage := sort $currentlyOnStage "Params.opening_date" "asc" }}
     {{ $comingSoon := sort $comingSoon "Params.opening_date" "asc" }}
     {{ $pastProductions := sort $pastProductions "Params.opening_date" "desc" }}
+    {{ $pastPaginator := .Paginate $pastProductions 10 }}
 
     {{/* Currently On Stage Section */}}
     {{ partial "production-section.html" (dict "sectionName" "Currently On Stage" "productions" $currentlyOnStage) }}
@@ -121,7 +122,8 @@
     {{ partial "production-section.html" (dict "sectionName" "Coming Soon!" "productions" $comingSoon) }}
 
     {{/* Past Productions Section */}}
-    {{ partial "production-section.html" (dict "sectionName" "Past Productions" "productions" $pastProductions) }}
+    {{ partial "production-section.html" (dict "sectionName" "Past Productions" "productions" $pastPaginator.Pages) }}
+    {{ template "_internal/pagination.html" . }}
 
     <!-- END Theatre Productions Section -->
 


### PR DESCRIPTION
## Summary
- paginate theatre past production list at 10 items per page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c19613a0c83249b6dd91f401facf0