### PR TITLE
perf: cache repeated person lookups in production templates

### DIFF
--- a/themes/jaxplays/layouts/_default/baseof.html
+++ b/themes/jaxplays/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     
-    <title>{{ partial "func/GetTitle.html" . }}</title>
+    <title>{{ partialCached "func/GetTitle.html" . .RelPermalink }}</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     {{ partial "func/GetDescription.html" . }}
     <meta name="description" content="{{ .Scratch.Get "finalDescription" }}">
@@ -25,7 +25,7 @@
     {{ end -}}
 
     {{ partialCached "site-style.html" . "site-style-v1" }}
-    {{ partial "site-scripts.html" . }}
+    {{ partialCached "site-scripts.html" . "site-scripts-v1" }}
     
     {{ block "favicon" . }}
       {{ partialCached "site-favicon.html" . }}

--- a/themes/jaxplays/layouts/_default/baseof.html
+++ b/themes/jaxplays/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
       <link rel="canonical" href="{{ .Permalink }}" itemprop="url" />
     {{ end -}}
 
-    {{ partial "site-style.html" . }}
+    {{ partialCached "site-style.html" . "site-style-v1" }}
     {{ partial "site-scripts.html" . }}
     
     {{ block "favicon" . }}

--- a/themes/jaxplays/layouts/_default/production-list.html
+++ b/themes/jaxplays/layouts/_default/production-list.html
@@ -2,16 +2,26 @@
 {{ $featuredImageAlt := .Params.featured_image_alt }}
 {{ $genres := .Params.genres }}
 
+{{/* Build once per render: show pages index keyed by title */}}
+{{ $showIndexKey := "jaxplays/shows-by-title-v1" }}
+{{ $showsByTitle := .Site.Store.Get $showIndexKey }}
+{{ if not $showsByTitle }}
+{{ $showsByTitle = dict }}
+{{ range where .Site.RegularPages "Type" "shows" }}
+{{ $showsByTitle = merge $showsByTitle (dict .Title .) }}
+{{ end }}
+{{ .Site.Store.Set $showIndexKey $showsByTitle }}
+{{ end }}
+{{ $showPage := index $showsByTitle .Title }}
+
 {{ if not $featuredImage }}
 {{ $defaultImage := "/media/default/production_poster.webp" }} <!-- Set default image path -->
 {{ $featuredImage = $defaultImage }} <!-- Use default image as the initial value -->
 {{ $featuredImageAlt := "Default production poster image" }}
-{{ range where .Site.Pages "Type" "shows" }}
-{{ if eq .Title $.Title }}
+{{ with $showPage }}
 {{ if .Params.featured_image }}
 {{ $featuredImage = printf "/media/posters/%s" .Params.featured_image }}
 {{ $featuredImageAlt := .Params.featured_image_alt }}
-{{ end }}
 {{ end }}
 {{ end }}
 {{ else }}
@@ -23,11 +33,9 @@
 {{ $showContent := "" }}
 
 {{ if not $description }}
-{{ range where .Site.Pages "Type" "shows" }}
-{{ if eq .Title $.Title }}
+{{ with $showPage }}
 {{ $description = .Params.description }}
 {{ $showContent = .Content }}
-{{ end }}
 {{ end }}
 {{ end }}
 
@@ -115,12 +123,8 @@
         <div class="flex flex-column items-start justify-start">
           <!-- Genres -->
           {{ $genres := .Params.genres }}
-          {{ if not $genres }}
-            {{ range where .Site.Pages "Type" "shows" }}
-              {{ if eq .Title $.Title }}
-                {{ $genres = .Params.genres }}
-              {{ end }}
-            {{ end }}
+          {{ if and (not $genres) $showPage }}
+            {{ $genres = $showPage.Params.genres }}
           {{ end }}
       
           {{ if $genres }}

--- a/themes/jaxplays/layouts/_default/production-list.html
+++ b/themes/jaxplays/layouts/_default/production-list.html
@@ -1,4 +1,4 @@
-{{ $featuredImage := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredImage := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 {{ $featuredImageAlt := .Params.featured_image_alt }}
 {{ $genres := .Params.genres }}
 

--- a/themes/jaxplays/layouts/_default/summary-with-image.html
+++ b/themes/jaxplays/layouts/_default/summary-with-image.html
@@ -1,4 +1,4 @@
-{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ $featured_image := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 <article class="bb b--black-10">
   <div class="db pv4 ph3 ph0-l no-underline dark-gray">
     <div class="flex flex-column flex-row-ns">

--- a/themes/jaxplays/layouts/_default/summary.html
+++ b/themes/jaxplays/layouts/_default/summary.html
@@ -1,4 +1,4 @@
-{{ $featuredImage := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredImage := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 {{ $contentLength := len .Summary }}
 {{ $isProductionOrShow := or (eq .Type "productions") (eq .Type "shows") }}  <!-- Check if the type is productions or shows -->
 

--- a/themes/jaxplays/layouts/_default/theatre-list.html
+++ b/themes/jaxplays/layouts/_default/theatre-list.html
@@ -1,4 +1,4 @@
-{{ $featuredImage := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredImage := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 {{ $contentLength := len .Summary }}
 
 {{ $summary := "" }} <!-- Declare $summary here -->

--- a/themes/jaxplays/layouts/partials/content-wikilinks.html
+++ b/themes/jaxplays/layouts/partials/content-wikilinks.html
@@ -1,73 +1,68 @@
 {{- /* layouts/partials/content-wikilinks.html */ -}}
-{{- $wikiregex := "\\[\\[([^\\]]+?)\\]\\]" -}}
-{{- $wikilinks := findRE $wikiregex . -}}
 {{- $content := . -}}
 {{- /* normalize curly apostrophes to reduce text-splitting corruption during replace passes */ -}}
 {{- $content = replace $content "’" "'" -}}
 {{- $markdownEmphasisRegex := "\\*([^\\*]+)\\*" -}} {{/* detect markdown emphasis with asterisks */}}
 
-{{- range $wikilinks -}}
-  {{- $linkText := replaceRE $wikiregex "$1" . -}}
-  {{- $parts := split $linkText "|" -}}
-  {{- $mainPart := index $parts 0 -}}
-  {{- $display := "" -}}
-  {{- $url := "" -}}
-
-  {{- $colonParts := split $mainPart ":" -}}
-  {{- $route := "" -}}
-
-  {{- if eq (len $parts) 2 -}}
-    {{- $display = index $parts 1 -}}
-  {{- else -}}
-    {{- $display = delimit (after 1 $colonParts) ":" -}}
-  {{- end -}}
-
+{{- if strings.Contains $content "[[" -}}
+  {{- $wikiregex := "\\[\\[([^\\]]+?)\\]\\]" -}}
+  {{- $wikilinks := findRE $wikiregex $content -}}
   {{- $routeMap := dict "person" "/people/" "production" "/productions/" "theatre" "/theatres/" "venue" "/venues/" -}}
-  {{- $isKnownPrefix := false -}}
-  {{- range $key, $val := $routeMap -}}
-    {{- if eq (index $colonParts 0) $key -}}
-      {{- $route = $val -}}
-      {{- $isKnownPrefix = true -}}
+
+  {{- range $wikilinks -}}
+    {{- $linkText := replaceRE $wikiregex "$1" . -}}
+    {{- $parts := split $linkText "|" -}}
+    {{- $mainPart := index $parts 0 -}}
+    {{- $display := "" -}}
+
+    {{- $colonParts := split $mainPart ":" -}}
+    {{- $prefix := index $colonParts 0 -}}
+    {{- $route := index $routeMap $prefix -}}
+
+    {{- if eq (len $parts) 2 -}}
+      {{- $display = index $parts 1 -}}
+    {{- else -}}
+      {{- $display = delimit (after 1 $colonParts) ":" -}}
     {{- end -}}
-  {{- end -}}
 
-  {{- if $isKnownPrefix -}}
-    {{- $internalURLize := delimit (after 1 $colonParts) ":" -}}
-    {{- $internalURLize = replace $internalURLize "&amp;" "and" -}}
-    {{- $internalURLize = replace $internalURLize "é" "e" -}}
-    {{- $internalURLize = replace $internalURLize "è" "e" -}}
-    {{- $internalURLize = replace $internalURLize "ê" "e" -}}
-    {{- $internalURLize = replace $internalURLize "ë" "e" -}}
-    {{- $internalURLize = replace $internalURLize "à" "a" -}}
-    {{- $internalURLize = replace $internalURLize "ä" "a" -}}
-    {{- $internalURLize = replace $internalURLize "â" "a" -}}
-    {{- $internalURLize = replace $internalURLize "ô" "o" -}}
-    {{- $internalURLize = replace $internalURLize "ö" "o" -}}
-    {{- $internalURLize = replace $internalURLize "ç" "c" -}}
-    {{- $url = printf "%s%s" $route ($internalURLize | urlize) -}}
+    {{- if $route -}}
+      {{- $internalURLize := delimit (after 1 $colonParts) ":" -}}
+      {{- $internalURLize = replace $internalURLize "&amp;" "and" -}}
+      {{- $internalURLize = replace $internalURLize "é" "e" -}}
+      {{- $internalURLize = replace $internalURLize "è" "e" -}}
+      {{- $internalURLize = replace $internalURLize "ê" "e" -}}
+      {{- $internalURLize = replace $internalURLize "ë" "e" -}}
+      {{- $internalURLize = replace $internalURLize "à" "a" -}}
+      {{- $internalURLize = replace $internalURLize "ä" "a" -}}
+      {{- $internalURLize = replace $internalURLize "â" "a" -}}
+      {{- $internalURLize = replace $internalURLize "ô" "o" -}}
+      {{- $internalURLize = replace $internalURLize "ö" "o" -}}
+      {{- $internalURLize = replace $internalURLize "ç" "c" -}}
+      {{- $url := printf "%s%s" $route ($internalURLize | urlize) -}}
 
-    {{- $style := "" -}}
-    {{- if eq (index $colonParts 0) "production" -}}
-      {{- $style = " style=\"font-style: italic;\"" -}}
-      {{- if eq (len $parts) 1 -}}
-        {{- if ge (len $display) 5 -}}
-          {{- $display = substr $display 5 -}}
-        {{- else -}}
-          {{- $display = "" -}}
+      {{- $style := "" -}}
+      {{- if eq $prefix "production" -}}
+        {{- $style = " style=\"font-style: italic;\"" -}}
+        {{- if eq (len $parts) 1 -}}
+          {{- if ge (len $display) 5 -}}
+            {{- $display = substr $display 5 -}}
+          {{- else -}}
+            {{- $display = "" -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
-    {{- end -}}
 
-    {{- $link := printf "<a%s href=\"%s\">%s</a>" $style $url $display -}}
-    {{- $content = replace $content . $link -}}
-  {{- else if eq (index $colonParts 0) "w" -}}
-    {{- $wikiName := delimit (after 1 $colonParts) ":" -}}
-    {{- $wikiName = replace $wikiName " " "_" -}}
-    {{- $wikiName = replace $wikiName "'" "%27" -}}
-    {{- $wikiName = replace $wikiName "&rsquo;" "%27" -}}
-    {{- $url = printf "https://en.wikipedia.org/wiki/%s" $wikiName -}}
-    {{- $link := printf "<a href=\"%s\" target=\"_blank\">%s</a>" $url $display -}}
-    {{- $content = replace $content . $link -}}
+      {{- $link := printf "<a%s href=\"%s\">%s</a>" $style $url $display -}}
+      {{- $content = replace $content . $link -}}
+    {{- else if eq $prefix "w" -}}
+      {{- $wikiName := delimit (after 1 $colonParts) ":" -}}
+      {{- $wikiName = replace $wikiName " " "_" -}}
+      {{- $wikiName = replace $wikiName "'" "%27" -}}
+      {{- $wikiName = replace $wikiName "&rsquo;" "%27" -}}
+      {{- $url := printf "https://en.wikipedia.org/wiki/%s" $wikiName -}}
+      {{- $link := printf "<a href=\"%s\" target=\"_blank\">%s</a>" $url $display -}}
+      {{- $content = replace $content . $link -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/themes/jaxplays/layouts/partials/findPerson.html
+++ b/themes/jaxplays/layouts/partials/findPerson.html
@@ -1,12 +1,25 @@
 {{ $urlName := .urlName | replaceRE "\\." "" | urlize }}
-{{ $foundPage := .site.GetPage (print "/people/" $urlName) }}
+{{ $site := .site }}
+{{ $foundPage := $site.GetPage (print "/people/" $urlName) }}
+
 {{ if not $foundPage }}
-  {{ range .site.Pages }}
-    {{ if and (eq .Type "people") (in .Params.aliases (print "/people/" $urlName)) }}
-      {{ $foundPage = . }}
+  {{ $aliasMap := $site.Store.Get "peopleAliasMap" }}
+  {{ if not $aliasMap }}
+    {{ $aliasMap = dict }}
+    {{ range where $site.Pages "Type" "people" }}
+      {{ $personPage := . }}
+      {{ range .Params.aliases }}
+        {{ $aliasSlug := . | replaceRE "^/people/" "" | replaceRE "/$" "" | replaceRE "\\." "" | urlize }}
+        {{ if $aliasSlug }}
+          {{ $aliasMap = merge $aliasMap (dict $aliasSlug $personPage) }}
+        {{ end }}
+      {{ end }}
     {{ end }}
+    {{ $site.Store.Set "peopleAliasMap" $aliasMap }}
   {{ end }}
+  {{ $foundPage = index $aliasMap $urlName }}
 {{ end }}
+
 {{ $defaultImage := "/media/default/people_headshot.webp" }}
 {{ if and .showImage }}
   {{ $imageToUse := $defaultImage }}

--- a/themes/jaxplays/layouts/partials/func/socials/opengraph.html
+++ b/themes/jaxplays/layouts/partials/func/socials/opengraph.html
@@ -1,4 +1,4 @@
-<meta property="og:title" content="{{ partial "func/GetTitle.html" . }}" />
+<meta property="og:title" content="{{ partialCached "func/GetTitle.html" . .RelPermalink }}" />
 {{/*  <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />  */}}
 
 <meta property="og:description" content="{{ .Scratch.Get "finalDescription" }}" />

--- a/themes/jaxplays/layouts/partials/func/socials/opengraph.html
+++ b/themes/jaxplays/layouts/partials/func/socials/opengraph.html
@@ -1,7 +1,6 @@
 <meta property="og:title" content="{{ partial "func/GetTitle.html" . }}" />
 {{/*  <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />  */}}
 
-{{ partial "func/GetDescription.html" . }}
 <meta property="og:description" content="{{ .Scratch.Get "finalDescription" }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />

--- a/themes/jaxplays/layouts/partials/page-header.html
+++ b/themes/jaxplays/layouts/partials/page-header.html
@@ -1,5 +1,5 @@
 {{- partialCached "site-navigation.html" . -}}
-{{- $featured_image := partial "func/GetFeaturedImage.html" . -}}
+{{- $featured_image := partialCached "func/GetFeaturedImage.html" . .RelPermalink -}}
 {{- $show := ne .Params.showFeaturedImage false -}}
 
 {{- if and $show $featured_image -}}

--- a/themes/jaxplays/layouts/partials/site-header.html
+++ b/themes/jaxplays/layouts/partials/site-header.html
@@ -1,4 +1,4 @@
-{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ $featured_image := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 {{ partialCached "site-navigation.html" .}}
 {{ if $featured_image }}
   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}

--- a/themes/jaxplays/layouts/partials/summary-with-image.html
+++ b/themes/jaxplays/layouts/partials/summary-with-image.html
@@ -1,7 +1,7 @@
 {{ partial "func/warn" `You are currently using 'partial "summary-with-image"' in your project templates. 
 You should replace it with '.Render "summary-with-image"' as the use of this partial will be deprecated in future releases.
 More info here: https://github.com/theNewDynamic/gohugo-theme-ananke/releases/tag/v2.8.1` }}
-{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ $featured_image := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
 <article class="bb b--black-10">
   <div class="db pv4 ph3 ph0-l no-underline dark-gray">
     <div class="flex flex-column flex-row-ns">

--- a/themes/jaxplays/layouts/people/list.html
+++ b/themes/jaxplays/layouts/people/list.html
@@ -10,7 +10,7 @@
       {{ $paginator := .Paginate $allPages 24 }}
       
       {{ range $paginator.Pages }}
-        {{ $featuredImage := partial "func/GetFeaturedImage.html" . }}
+        {{ $featuredImage := partialCached "func/GetFeaturedImage.html" . .RelPermalink }}
         {{ $contentLength := len .Summary }}
         {{ $summary := "" }}
         

--- a/themes/jaxplays/layouts/people/single.html
+++ b/themes/jaxplays/layouts/people/single.html
@@ -131,23 +131,23 @@
 
     <!-- Credits Section: Loop through different credit types and sort productions by opening_date -->
     {{ range $creditType := $creditTypes }}
-      {{ $productionsByPermalink := dict }}
+      {{ $creditsByProductionScratch := newScratch }}
       {{ range $name := $personNames }}
         {{ range $entry := (index $creditsIndex (printf "%s|%s" $creditType $name) | default (slice)) }}
           {{ $production := $entry.production }}
           {{ $credit := $entry.credit }}
           {{ $productionKey := $production.RelPermalink }}
-          {{ $existing := index $productionsByPermalink $productionKey }}
+          {{ $existing := index ($creditsByProductionScratch.Get "productions" | default (dict)) $productionKey }}
           {{ if $existing }}
-            {{ $productionsByPermalink = merge $productionsByPermalink (dict $productionKey (dict "production" $production "credits" (($existing.credits) | append $credit))) }}
+            {{ $creditsByProductionScratch.SetInMap "productions" $productionKey (dict "production" $production "credits" (($existing.credits) | append $credit)) }}
           {{ else }}
-            {{ $productionsByPermalink = merge $productionsByPermalink (dict $productionKey (dict "production" $production "credits" (slice $credit))) }}
+            {{ $creditsByProductionScratch.SetInMap "productions" $productionKey (dict "production" $production "credits" (slice $credit)) }}
           {{ end }}
         {{ end }}
       {{ end }}
 
       {{ $productionsWithPerson := slice }}
-      {{ range $productionsByPermalink }}
+      {{ range ($creditsByProductionScratch.Get "productions") }}
         {{ $productionsWithPerson = $productionsWithPerson | append . }}
       {{ end }}
       {{ $sortedProductions := sort $productionsWithPerson "production.Params.opening_date" "desc" }}
@@ -237,14 +237,14 @@
     <!-- END Credits Section -->
 
     <!-- Reviews -->
-    {{ $relatedReviewsByPermalink := dict }}
+    {{ $relatedReviewsScratch := newScratch }}
     {{ range $name := $personNames }}
     {{ range $review := (index $reviewIndex $name | default (slice)) }}
-    {{ $relatedReviewsByPermalink = merge $relatedReviewsByPermalink (dict $review.RelPermalink $review) }}
+    {{ $relatedReviewsScratch.SetInMap "reviews" $review.RelPermalink $review }}
     {{ end }}
     {{ end }}
     {{ $relatedReviews := slice }}
-    {{ range $relatedReviewsByPermalink }}
+    {{ range ($relatedReviewsScratch.Get "reviews") }}
     {{ $relatedReviews = $relatedReviews | append . }}
     {{ end }}
 

--- a/themes/jaxplays/layouts/people/single.html
+++ b/themes/jaxplays/layouts/people/single.html
@@ -3,6 +3,53 @@
 {{ $personName := .Title }} <!-- Assuming the page title is the person's name -->
 {{ $otherNames := .Params.other_names | default slice }} <!-- Getting other names from the front matter -->
 {{ $personNames := slice $personName | append $otherNames }} <!-- Combining the title and other names into a slice -->
+{{ $creditTypes := slice "cast" "understudies" "crew" "orchestra" }}
+
+{{/* Build once per site render: credits index keyed by "creditType|personName" */}}
+{{ $creditsIndexKey := "jaxplays/people-credits-index-v1" }}
+{{ $creditsIndex := .Site.Store.Get $creditsIndexKey }}
+{{ if not $creditsIndex }}
+  {{ $creditsScratch := newScratch }}
+  {{ range where .Site.RegularPages "Type" "productions" }}
+    {{ $production := . }}
+    {{ range $creditType := $creditTypes }}
+      {{ with index $production.Params $creditType }}
+        {{ range . }}
+          {{ range $character, $actor := . }}
+            {{ $actorSlice := slice }}
+            {{ if eq (printf "%T" $actor) "string" }}
+              {{ $actorSlice = slice $actor }}
+            {{ else }}
+              {{ $actorSlice = $actor }}
+            {{ end }}
+            {{ range $actorName := $actorSlice }}
+              {{ $creditsScratch.Add (printf "%s|%s" $creditType $actorName) (slice (dict "production" $production "credit" $character)) }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ $creditsIndex = $creditsScratch.Values }}
+  {{ .Site.Store.Set $creditsIndexKey $creditsIndex }}
+{{ end }}
+
+{{/* Build once per site render: reviews index keyed by cast name */}}
+{{ $reviewIndexKey := "jaxplays/reviews-by-cast-name-v1" }}
+{{ $reviewIndex := .Site.Store.Get $reviewIndexKey }}
+{{ if not $reviewIndex }}
+  {{ $reviewsScratch := newScratch }}
+  {{ range where .Site.RegularPages "Type" "reviews" }}
+    {{ $review := . }}
+    {{ range $castName := (.Params.cast | default (slice)) }}
+      {{ if eq (printf "%T" $castName) "string" }}
+        {{ $reviewsScratch.Add $castName (slice $review) }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ $reviewIndex = $reviewsScratch.Values }}
+  {{ .Site.Store.Set $reviewIndexKey $reviewIndex }}
+{{ end }}
 
 <div class="flex-l mt0 w-100 mw8 center">
   <article class="center cf pv4 ph3 ph4-ns w-100 mw8">
@@ -71,37 +118,26 @@
       {{ end }}
     </div>
 
-    {{ $global := . }} <!-- Capture the global context to use inside range blocks -->
-
     <!-- Credits Section: Loop through different credit types and sort productions by opening_date -->
-    {{ $creditTypes := slice "cast" "understudies" "crew" "orchestra" }}
     {{ range $creditType := $creditTypes }}
-      {{ $productionsWithPerson := slice }}
-      {{ range where $global.Site.Pages "Type" "productions" }} <!-- Use $global to access .Site.Pages -->
-        {{ $production := . }}
-        {{ with index .Params $creditType }}
-          {{ $credits := slice }}
-          {{ range . }}
-            {{ range $character, $actor := . }}
-              {{ $actorSlice := slice }}
-              {{ if eq (printf "%T" $actor) "string" }}
-                {{ $actorSlice = slice $actor }}
-              {{ else }}
-                {{ $actorSlice = $actor }}
-              {{ end }}
-              {{ range $name := $personNames }}
-                {{ range $actorName := $actorSlice }}
-                  {{ if eq $actorName $name }}
-                    {{ $credits = $credits | append $character }}
-                  {{ end }}
-                {{ end }}
-              {{ end }}
-            {{ end }}
-          {{ end }}
-          {{ if $credits }}
-            {{ $productionsWithPerson = $productionsWithPerson | append (dict "production" $production "credits" $credits) }}
+      {{ $productionsByPermalink := dict }}
+      {{ range $name := $personNames }}
+        {{ range $entry := (index $creditsIndex (printf "%s|%s" $creditType $name) | default (slice)) }}
+          {{ $production := $entry.production }}
+          {{ $credit := $entry.credit }}
+          {{ $productionKey := $production.RelPermalink }}
+          {{ $existing := index $productionsByPermalink $productionKey }}
+          {{ if $existing }}
+            {{ $productionsByPermalink = merge $productionsByPermalink (dict $productionKey (dict "production" $production "credits" (($existing.credits) | append $credit))) }}
+          {{ else }}
+            {{ $productionsByPermalink = merge $productionsByPermalink (dict $productionKey (dict "production" $production "credits" (slice $credit))) }}
           {{ end }}
         {{ end }}
+      {{ end }}
+
+      {{ $productionsWithPerson := slice }}
+      {{ range $productionsByPermalink }}
+        {{ $productionsWithPerson = $productionsWithPerson | append . }}
       {{ end }}
       {{ $sortedProductions := sort $productionsWithPerson "production.Params.opening_date" "desc" }}
 
@@ -190,16 +226,15 @@
     <!-- END Credits Section -->
 
     <!-- Reviews -->
+    {{ $relatedReviewsByPermalink := dict }}
+    {{ range $name := $personNames }}
+    {{ range $review := (index $reviewIndex $name | default (slice)) }}
+    {{ $relatedReviewsByPermalink = merge $relatedReviewsByPermalink (dict $review.RelPermalink $review) }}
+    {{ end }}
+    {{ end }}
     {{ $relatedReviews := slice }}
-    {{ range where site.RegularPages "Type" "reviews" }}
-    {{ $review := . }} <!-- Store the current review in a variable -->
-    {{ range $name := $personNames }} <!-- Looping through all the person's names -->
-    {{ if in $review.Params.cast $name }}
-    {{ $relatedReviews = $relatedReviews | append $review }}
-    <!-- Appending the entire review object if a name is found in cast list -->
-    {{ break }} <!-- Break the inner loop if a match is found, to avoid duplicate appending -->
-    {{ end }}
-    {{ end }}
+    {{ range $relatedReviewsByPermalink }}
+    {{ $relatedReviews = $relatedReviews | append . }}
     {{ end }}
 
     {{ if or $relatedReviews .Params.reviews }}

--- a/themes/jaxplays/layouts/people/single.html
+++ b/themes/jaxplays/layouts/people/single.html
@@ -5,6 +5,17 @@
 {{ $personNames := slice $personName | append $otherNames }} <!-- Combining the title and other names into a slice -->
 {{ $creditTypes := slice "cast" "understudies" "crew" "orchestra" }}
 
+{{/* Build once per render: show pages index keyed by title */}}
+{{ $showIndexKey := "jaxplays/shows-by-title-v1" }}
+{{ $showsByTitle := .Site.Store.Get $showIndexKey }}
+{{ if not $showsByTitle }}
+  {{ $showsByTitle = dict }}
+  {{ range where .Site.RegularPages "Type" "shows" }}
+    {{ $showsByTitle = merge $showsByTitle (dict .Title .) }}
+  {{ end }}
+  {{ .Site.Store.Set $showIndexKey $showsByTitle }}
+{{ end }}
+
 {{/* Build once per site render: credits index keyed by "creditType|personName" */}}
 {{ $creditsIndexKey := "jaxplays/people-credits-index-v1" }}
 {{ $creditsIndex := .Site.Store.Get $creditsIndexKey }}
@@ -152,7 +163,7 @@
           <div class="w-25 w-10-l">
             {{ $featuredImage := $details.production.Params.featured_image }}
             {{ if not $featuredImage }}
-            {{ with (site.GetPage "page" (printf "/shows/%s" ($details.production.Title | urlize))) }}
+            {{ with (index $showsByTitle $details.production.Title) }}
             {{ $featuredImage = .Params.featured_image }}
             {{ end }}
             {{ end }}

--- a/themes/jaxplays/layouts/productions/past.html
+++ b/themes/jaxplays/layouts/productions/past.html
@@ -4,23 +4,17 @@
     {{ .Content }}
   </section>-->
   {{ partial "secondSearchBar.html" (dict "section" "Productions") }}
-  {{ $currentDate := now.Format "2006-01-02" }}
+  {{ $nowUnix := now.Unix }}
   {{ $pastProductions := slice }}
-  
-  {{ range where .Site.Pages "Type" "productions" }}
-    {{ $openingDate := "" }}
-    {{ $endDate := "" }}
-    {{ with .Params.opening_date }}
-      {{ $openingDate = time . | time.Format "2006-01-02" }}
-    {{ end }}
-    {{ with .Params.closing_date }}
-      {{ $endDate = time . | time.Format "2006-01-02" }}
-    {{ else }}
-      {{ $endDate = $openingDate }}  <!-- Use opening_date as closing_date if closing_date is not provided -->
-    {{ end }}
-    {{ if and $openingDate $endDate }}
-      {{ if and (lt $openingDate $currentDate) (lt $endDate $currentDate) }} <!-- Checking both opening and closing dates are in the past -->
-        {{ $pastProductions = $pastProductions | append (dict "page" . "sort_date" $endDate) }}
+
+  {{ range where .Site.RegularPages "Type" "productions" }}
+    {{ $openingDate := .Params.opening_date }}
+    {{ $closingDate := .Params.closing_date | default $openingDate }}
+    {{ if and $openingDate $closingDate }}
+      {{ $openingTime := time $openingDate }}
+      {{ $closingTime := time $closingDate }}
+      {{ if and (lt $openingTime.Unix $nowUnix) (lt $closingTime.Unix $nowUnix) }}
+        {{ $pastProductions = $pastProductions | append (dict "page" . "sort_date" $closingTime.Unix) }}
       {{ end }}
     {{ end }}
   {{ end }}

--- a/themes/jaxplays/layouts/productions/single.html
+++ b/themes/jaxplays/layouts/productions/single.html
@@ -4,10 +4,18 @@
 {{ $contentLength := len .Content }}
 {{ $description := .Params.description }}
 {{ $showContent := "" }}
-{{ $showPage := false }}
-{{ with first 1 (where (where .Site.RegularPages "Type" "shows") "Title" .Title) }}
-{{ $showPage = index . 0 }}
+
+{{/* Build once per render: show pages index keyed by title */}}
+{{ $showIndexKey := "jaxplays/shows-by-title-v1" }}
+{{ $showsByTitle := .Site.Store.Get $showIndexKey }}
+{{ if not $showsByTitle }}
+{{ $showsByTitle = dict }}
+{{ range where .Site.RegularPages "Type" "shows" }}
+{{ $showsByTitle = merge $showsByTitle (dict .Title .) }}
 {{ end }}
+{{ .Site.Store.Set $showIndexKey $showsByTitle }}
+{{ end }}
+{{ $showPage := index $showsByTitle .Title }}
 
 {{ if and (not $description) $showPage }}
 {{ $description = $showPage.Params.description }}
@@ -159,29 +167,42 @@
       {{ $currentPage := . }} <!-- Capture the current page context -->
       {{ $venues := .Params.venue }} <!-- Get the venue(s) -->
 
+      {{/* Build once per render: venue lookups by slug + alias */}}
+      {{ $venueLookupKey := "jaxplays/venues-lookup-v1" }}
+      {{ $venueLookup := .Site.Store.Get $venueLookupKey }}
+      {{ if not $venueLookup }}
+      {{ $venuesBySlug := dict }}
+      {{ $venuesByAlias := dict }}
+      {{ range where .Site.RegularPages "Type" "venues" }}
+      {{ $venuePage := . }}
+      {{ $slug := .File.BaseFileName | replaceRE "\\." "" | urlize }}
+      {{ $venuesBySlug = merge $venuesBySlug (dict $slug $venuePage) }}
+      {{ range (.Params.venue_aliases | default (slice)) }}
+      {{ $aliasSlug := . | replaceRE "\\." "" | urlize }}
+      {{ if $aliasSlug }}
+      {{ $venuesByAlias = merge $venuesByAlias (dict $aliasSlug $venuePage) }}
+      {{ end }}
+      {{ end }}
+      {{ end }}
+      {{ $venueLookup = dict "bySlug" $venuesBySlug "byAlias" $venuesByAlias }}
+      {{ .Site.Store.Set $venueLookupKey $venueLookup }}
+      {{ end }}
+      {{ $venuesBySlug := index $venueLookup "bySlug" }}
+      {{ $venuesByAlias := index $venueLookup "byAlias" }}
+
       {{ if eq (printf "%T" $venues) "string" }} <!-- Check if it's a string -->
       {{ $venues = slice $venues }} <!-- Convert to an array if it's a single string -->
       {{ end }}
 
       {{ range $index, $venue := $venues }}
-      {{ $venueurl := $venue }}
-      {{ $venueurl = replaceRE " & " "-and-" $venueurl }}
-      {{ $venueurl = replaceRE " " "-" $venueurl }}
-      {{ $venueurl = replaceRE "\\." "" $venueurl }}
-      {{ $venueurl = $venueurl | urlize }}
-      {{ $venuePage := $currentPage.Site.GetPage "page" (printf "/venues/%s" $venueurl) }}
-      {{ $displayVenue := $venue }}
+      {{ $venueurl := $venue | replaceRE " & " "-and-" | replaceRE " " "-" | replaceRE "\\." "" | urlize }}
+      {{ $venuePage := index $venuesBySlug $venueurl }}
       {{ if not $venuePage }}
-      {{ range where $currentPage.Site.Pages "Section" "venues" }}
-      {{ if in .Params.venue_aliases $venue }}
-      {{ $venuePage = . }}
-      {{ $venueurl = .Title | urlize | replaceRE "\\." "" }}
-      {{ $displayVenue = $venue }}
+      {{ $venuePage = index $venuesByAlias ($venue | replaceRE "\\." "" | urlize) }}
       {{ end }}
+      {{ if $venuePage }}
+      {{ $venueurl = $venuePage.File.BaseFileName | replaceRE "\\." "" | urlize }}
       {{ end }}
-      {{ end }}
-
-      <!-- Now use $displayVenue wherever you used to use $venue for display -->
 
       <div class="flex flex-column flex-row-ns">
         <div class="w-100 w-25-l w-40-m pa3-ns pa2 bb bw1 b--silver flex flex-row flex-column-ns">
@@ -194,8 +215,6 @@
           </div>
           <div class="w-75 w-100-ns ph1 ph0-ns">
             <a class="b db mb3" href="/venues/{{ $venueurl }}">{{ with $venuePage.Params.building }}<span>{{ . }}</span><br/>{{ end }}{{ $venue }}</a>
-            {{ $venuePage := $currentPage.Site.GetPage "page" (printf "/venues/%s" ($venueurl)) }}
-            <!-- Use the captured page context -->
             {{ with $venuePage.Params.address }} <!-- Access the 'Address' parameter -->
             {{ . | replaceRE "\n" "<br />" | safeHTML }} <!-- Display the address with line breaks -->
             <a href="#showHideMap" class="db dn-ns mv3">Show Maps</a>
@@ -210,8 +229,7 @@
         <div class="venuemaps db-ns dn w-100 w-60-m w-75-l pa3-ns pv4 bb bw1 b--silver">
           <!-- Venue Map Section -->
           <div class="w-100 flex flex-column items-center justify-start">
-            {{ if and $venuePage.Params.latitude $venuePage.Params.longitude }}
-            {{ $venuePage := $currentPage.Site.GetPage "page" (printf "/venues/%s" ($venueurl)) }}
+            {{ if and $venuePage $venuePage.Params.latitude $venuePage.Params.longitude }}
             {{ partial "leaflet.html" (dict "Latitude" $venuePage.Params.latitude "Longitude"
             $venuePage.Params.longitude "Title" $venue "Address" $venuePage.Params.address "id" $index) }}
             {{ end }}
@@ -220,7 +238,6 @@
 
       </div>
       {{ end }}
-
 
       <!-- Dates Section -->
       {{ if and .Params.opening_date .Params.closing_date }}
@@ -418,13 +435,23 @@
 
     <!-- Reviews -->
     {{ $filename := .File.BaseFileName | replaceRE "-" " " | lower }}
-    {{ $relatedReviews := slice }}
+    {{/* Build once per render: reviews index by production title key (case-insensitive) */}}
+    {{ $reviewsIndexKey := "jaxplays/reviews-by-production-v1" }}
+    {{ $reviewsByProduction := .Site.Store.Get $reviewsIndexKey }}
+    {{ if not $reviewsByProduction }}
+    {{ $reviewsScratch := newScratch }}
     {{ range where site.RegularPages "Type" "reviews" }}
-      {{ $reviewProduction := .Params.production | default "" | lower }}
-      {{ if eq $reviewProduction $filename }}
-        {{ $relatedReviews = $relatedReviews | append . }}
-      {{ end }}
+    {{ $review := . }}
+    {{ with $review.Params.production }}
+    {{ if eq (printf "%T" .) "string" }}
+    {{ $reviewsScratch.Add (. | lower) (slice $review) }}
     {{ end }}
+    {{ end }}
+    {{ end }}
+    {{ $reviewsByProduction = $reviewsScratch.Values }}
+    {{ .Site.Store.Set $reviewsIndexKey $reviewsByProduction }}
+    {{ end }}
+    {{ $relatedReviews := index $reviewsByProduction $filename | default (slice) }}
 
     {{ if or $relatedReviews .Params.reviews }}
     <div class="nested-copy-line-height lh-copy f4 mt5 {{ $.Param " text_color" | default "dark-gray" }}">

--- a/themes/jaxplays/layouts/productions/single.html
+++ b/themes/jaxplays/layouts/productions/single.html
@@ -4,14 +4,14 @@
 {{ $contentLength := len .Content }}
 {{ $description := .Params.description }}
 {{ $showContent := "" }}
+{{ $showPage := false }}
+{{ with first 1 (where (where .Site.RegularPages "Type" "shows") "Title" .Title) }}
+{{ $showPage = index . 0 }}
+{{ end }}
 
-{{ if not $description }}
-{{ range where .Site.Pages "Type" "shows" }}
-{{ if eq .Title $.Title }}
-{{ $description = .Params.description }}
-{{ $showContent = .Content }}
-{{ end }}
-{{ end }}
+{{ if and (not $description) $showPage }}
+{{ $description = $showPage.Params.description }}
+{{ $showContent = $showPage.Content }}
 {{ end }}
 
 {{ if not $description }}
@@ -62,24 +62,16 @@
     {{ $featuredImageAttrLink := .Params.featured_image_attr_link }}
     {{ $genres := .Params.genres }}
 
-    {{ if not $featuredImage }}
-    {{ range where .Site.Pages "Type" "shows" }}
-    {{ if eq .Title $.Title }}
-    {{ $featuredImage = .Params.featured_image }}
-    {{ $featuredImageAlt := .Params.featured_image_alt }}
-    {{ $featuredImageCaption = .Params.featured_image_caption }}
-    {{ $featuredImageAttr = .Params.featured_image_attr }}
-    {{ $featuredImageAttrLink := .Params.featured_image_attr_link }}
-    {{ end }}
-    {{ end }}
+    {{ if and (not $featuredImage) $showPage }}
+    {{ $featuredImage = $showPage.Params.featured_image }}
+    {{ $featuredImageAlt = $showPage.Params.featured_image_alt }}
+    {{ $featuredImageCaption = $showPage.Params.featured_image_caption }}
+    {{ $featuredImageAttr = $showPage.Params.featured_image_attr }}
+    {{ $featuredImageAttrLink = $showPage.Params.featured_image_attr_link }}
     {{ end }}
 
-    {{ if not $genres }}
-    {{ range where .Site.Pages "Type" "shows" }}
-    {{ if eq .Title $.Title }}
-    {{ $genres = .Params.genres }}
-    {{ end }}
-    {{ end }}
+    {{ if and (not $genres) $showPage }}
+    {{ $genres = $showPage.Params.genres }}
     {{ end }}
 
     {{ if or $featuredImage $genres }}
@@ -293,12 +285,8 @@
       <!-- Show Details -->
       {{ $showDetails := .Params.show_details }}
 
-      {{ if not $showDetails }}
-      {{ range where .Site.Pages "Type" "shows" }}
-      {{ if eq .Title $.Title }}
-      {{ $showDetails = .Params.show_details }}
-      {{ end }}
-      {{ end }}
+      {{ if and (not $showDetails) $showPage }}
+      {{ $showDetails = $showPage.Params.show_details }}
       {{ end }}
 
       {{ if $showDetails }}
@@ -337,10 +325,8 @@
     <!-- Synopsis -->
 
     {{ $showSynopsis := "" }}
-    {{ range where .Site.Pages "Type" "shows" }}
-    {{ if eq .Title $.Title }}
+    {{ with $showPage }}
     {{ $showSynopsis = .Content }}
-    {{ end }}
     {{ end }}
 
     {{ if or .Content $showSynopsis }}

--- a/themes/jaxplays/layouts/productions/single.html
+++ b/themes/jaxplays/layouts/productions/single.html
@@ -376,14 +376,14 @@
                   <div class="cast-array-wrapper">
                   <div class="scroll-cast">
                     {{ range $idx, $p := $person }}
-                    {{ $output := partial "findPerson.html" (dict "urlName" $p "site" $site "showImage" "true" "isArray" true) }}
+                    {{ $output := partialCached "findPerson.html" (dict "urlName" $p "site" $site "showImage" "true") $p "img" }}
                     {{ $output := chomp $output }}
                     {{ $output | safeHTML }}
                     {{ end }}
                   </div>
                   </div>
                 {{ else }}
-                  {{ $output := partial "findPerson.html" (dict "urlName" $person "site" $site "showImage" "true" "isArray" false) }}
+                  {{ $output := partialCached "findPerson.html" (dict "urlName" $person "site" $site "showImage" "true") $person "img" }}
                   {{ $output := chomp $output }}
                   {{ $output | safeHTML }}
                 {{ end }}

--- a/themes/jaxplays/layouts/productions/single.html
+++ b/themes/jaxplays/layouts/productions/single.html
@@ -1,4 +1,4 @@
-{{ define "header" }}{{ partial "production-header.html" . }}{{ end }}
+{{ define "header" }}{{ partialCached "production-header.html" . .RelPermalink }}{{ end }}
 {{ define "main" }}
 
 {{ $contentLength := len .Content }}


### PR DESCRIPTION
## Summary\n- cache person alias resolution in  using  so misses no longer scan all pages\n- switch production cast/crew rendering calls to  for repeated person cards\n- keep rendered markup and routes unchanged\n\n## Validation\n- Start building sites … 
hugo v0.156.0+extended+withdeploy darwin/arm64 BuildDate=2026-02-18T16:39:55Z VendorInfo=Homebrew


Template Metrics:

       cumulative       average       maximum      cache  percent  cached  total  
         duration      duration      duration  potential   cached   count  count  template
       ----------      --------      --------  ---------  -------  ------  -----  --------
   4m47.68486078s  139.517391ms    287.1465ms          0        0       0   2062  people/single.html
    18.560677311s   15.836755ms   89.177834ms          0        0       0   1172  productions/single.html
     5.230735581s   24.908264ms  119.707917ms          0        0       0    210  _default/taxonomy.html
     4.555149464s     254.733µs   29.195583ms          0        0       0  17882  summary.html
     2.552089287s   52.083454ms   73.118458ms          0        0       0     49  productions/past.html
     1.569899133s    1.339504ms   14.090792ms          0        0       0   1172  production-list.html
     1.557438539s   21.334774ms      56.771ms          0        0       0     73  venues/single.html
     1.523593996s    6.653248ms   28.953083ms          0        0       0    229  single.html
     1.112788984s     279.244µs   15.566625ms         24        0       0   3985  _partials/func/socials/opengraph.html
     1.091798658s     136.988µs   34.006334ms        100        0       0   7970  _partials/func/getdescription.html
     1.074567083s  1.074567083s  1.074567083s          0        0       0      1  shows/list.html
     1.024518832s   20.490376ms   50.594083ms          0        0       0     50  theatres/single.html
      783.93121ms      196.72µs   28.990542ms        100        0       0   3985  _partials/site-style.html
     554.795667ms  554.795667ms  554.795667ms          0        0       0      1  venues/list.html
     527.990917ms    6.139429ms   23.147875ms          0        0       0     86  people/list.html
     488.296666ms  488.296666ms  488.296666ms          0        0       0      1  theatres/list.html
     452.317425ms    2.239195ms    8.378833ms         30        0       0    202  _partials/production_details_for_review.html
     450.645711ms      15.192µs   28.172584ms          0        0       0  29662  _partials/content-wikilinks.html
     392.953167ms  392.953167ms  392.953167ms          0        0       0      1  page/allcredits.html
     313.688793ms      93.443µs     4.92375ms        100       61    2061   3357  _partials/production-header.html
     269.964702ms      12.341µs   11.270458ms         32        0       0  21874  _partials/func/getfeaturedimage.html
       216.0315ms    216.0315ms    216.0315ms          0        0       0      1  reviews/rss.xml
     190.498433ms       5.707µs    9.569917ms         72       62   20593  33374  _partials/findperson.html
     185.970965ms      23.333µs    47.30525ms        100        0       0   7970  _partials/_funcs/get-page-images.html
     154.378332ms   14.034393ms   30.479708ms          0        0       0     11  _default/author.html
     140.869944ms     579.711µs    8.343208ms         92        0       0    243  _partials/page-header.html
     126.957126ms   12.695712ms     36.8725ms          0        0       0     10  list.html
        120.904ms     314.036µs    9.773708ms         98        0       0    385  _partials/site-header.html
     107.696854ms     162.438µs   10.798125ms         18        0       0    663  _partials/social-media-links.html
     101.740581ms     764.966µs    40.51925ms          0        0       0    133  rss.xml
      96.384415ms     420.892µs    8.680791ms         98        0       0    229  _partials/social-share.html
      85.895834ms   85.895834ms   85.895834ms          0        0       0      1  news/rss.xml
      72.462745ms       9.091µs     440.667µs         45        0       0   7970  _partials/func/gettitle.html
      70.504833ms   35.252416ms   35.271042ms          0        0       0      2  about/brand-guidelines.html
      69.973541ms    34.98677ms   35.225458ms          0        0       0      2  about/about.html
      59.213833ms   59.213833ms   59.213833ms          0        0       0      1  index.json
      45.859792ms   45.859792ms   45.859792ms          0        0       0      1  index.html
      42.926793ms   10.731698ms   34.917667ms          0        0       0      4  _default/author.terms.html
      42.659288ms       49.09µs    1.438917ms         41        1       5    869  _partials/func/socials/getserviceicon.html
      38.593584ms   38.593584ms   38.593584ms          0        0       0      1  productions/list.html
      37.840958ms   37.840958ms   37.840958ms          0        0       0      1  index.calendar.json
       35.36125ms    35.36125ms    35.36125ms          0        0       0      1  about/single-noheader.html
      35.199333ms   35.199333ms   35.199333ms          0        0       0      1  404.html
         31.555ms      31.555ms      31.555ms          0        0       0      1  page/opening_nights_calendar.html
      28.909295ms     132.005µs    12.58375ms         65        0       0    219  _partials/venue-production-section.html
      28.154499ms     103.509µs    1.480208ms         13        0       0    272  _partials/inline/pagination/default.html
       28.07992ms      226.45µs      14.186ms          0        0       0    124  theatre-list.html
       27.69875ms     184.658µs   13.104708ms         64        0       0    150  _partials/production-section.html
        27.6965ms     27.6965ms     27.6965ms          0        0       0      1  sitemap.xml
      27.411917ms   27.411917ms   27.411917ms          0        0       0      1  calendar/opening-and-closing.html
      25.557163ms      13.283µs    2.599541ms        100      100    1923   1924  _partials/site-navigation.html
       19.31975ms    19.31975ms    19.31975ms          0        0       0      1  productions/future.html
      17.618813ms       4.421µs    4.295584ms        100      100    3984   3985  _partials/site-footer.html
      17.603276ms       4.417µs    1.839333ms        100      100    3984   3985  _partials/func/style/getmaincss.html
      16.467585ms     216.678µs    3.941417ms          0        0       0     76  _shortcodes/figure.html
      14.533125ms   14.533125ms   14.533125ms          0        0       0      1  index.opening_nights_calendar.ics
      14.392314ms       8.314µs    4.083667ms        100        0       0   1731  _partials/cta_submit_profile.html
      13.614063ms       3.416µs     399.167µs        100        0       0   3985  _partials/site-scripts.html
      13.194246ms        3.31µs      441.25µs        100      100    3984   3985  _partials/func/getlanguagedirection.html
      11.142415ms    3.714138ms   10.883666ms          0        0       0      3  productions/rss.xml
      11.102542ms      48.482µs    7.182416ms         12        0       0    229  _partials/infinitescroll.html
      10.913917ms   10.913917ms   10.913917ms          0        0       0      1  index.opening_nights.json
      10.632125ms   10.632125ms   10.632125ms          0        0       0      1  corporate-sponsors/thank-you.html
      10.390375ms   10.390375ms   10.390375ms          0        0       0      1  calendar/opening-nights.html
      10.150664ms      43.752µs    3.187583ms        100       99     229    232  _partials/func/socials/get.html
       9.689802ms       2.431µs     4.59075ms        100      100    3984   3985  _partials/site-favicon.html
       9.659805ms       9.999µs      75.292µs         27        0       0    966  _partials/leaflet.html
       4.842194ms      14.991µs     107.792µs          0        0       0    323  alias.html
       4.507665ms      54.971µs     168.333µs          0        0       0     82  _shortcodes/youtube.html
       4.439014ms       1.113µs     171.084µs        100        0       0   3985  _partials/head-additions.html
       4.373423ms      20.154µs     105.708µs          7        0       0    217  _partials/figure.html
       4.086833ms    4.086833ms    4.086833ms          0        0       0      1  submit/production.html
       3.397833ms    3.397833ms    3.397833ms          0        0       0      1  submit/profile.html
       3.211867ms        2.29µs     106.292µs         96        0       0   1402  _partials/gam-right-rail-1.html
       3.141126ms      95.185µs     449.417µs          0        0       0     33  _shortcodes/columns.html
       3.110793ms      53.634µs      172.25µs         94        0       0     58  _partials/embed-pdf.html
       3.055584ms    3.055584ms    3.055584ms          0        0       0      1  theatres/contacts.html
         2.8645ms      2.8645ms      2.8645ms          0        0       0      1  theatres/contacts.json.json
       2.770292ms    2.770292ms    2.770292ms          0        0       0      1  page/signup.html
       2.336827ms       1.666µs      41.166µs         88        0       0   1402  _partials/gam-left-rail-1.html
         2.2185ms      2.2185ms      2.2185ms          0        0       0      1  page/new-signup.html
       1.784375ms    1.784375ms    1.784375ms          0        0       0      1  submit/list.html
       1.671542ms    1.671542ms    1.671542ms          0        0       0      1  submit/form-render.html
        1.63575ms     1.63575ms     1.63575ms          0        0       0      1  calendar/calendar.html
       1.630959ms    1.630959ms    1.630959ms          0        0       0      1  page/qr.html
         1.6155ms       3.874µs      40.042µs        100        0       0    417  _partials/cta_edit_profile.html
       1.383334ms     461.111µs    1.146667ms        100       33       1      3  _partials/social-follow.html
        1.24579ms      83.052µs         902µs         20       33       5     15  _partials/func/socials/getservicedata.html
       1.011958ms    1.011958ms    1.011958ms          0        0       0      1  submit/form-builder.html
        959.831µs       6.905µs     126.208µs         99        0       0    139  _partials/secondsearchbar.html
        959.792µs     159.965µs     473.625µs          0        0       0      6  summary-with-image.html
        926.598µs         508ns      24.458µs        100        0       0   1822  _partials/gam-billboard-1.html
        905.666µs       7.363µs     181.625µs          0        0       0    123  by.html
            764µs         764µs         764µs          0        0       0      1  submit/theatre.html
          754.5µs       754.5µs       754.5µs          0        0       0      1  page/support.html
        435.334µs     108.833µs     165.125µs          0        0       0      4  _shortcodes/seatmap.html
        417.261µs       1.822µs       6.083µs        100        0       0    229  _partials/tags.html
         277.25µs      69.312µs      98.042µs         54        0       0      4  _partials/seatmap.html
        270.791µs     270.791µs     270.791µs          0        0       0      1  robots.txt
        170.667µs      21.333µs        51.5µs         12        0       0      8  _partials/func/style/getresource.html
         150.04µs      15.004µs     137.209µs        100       80       8     10  _partials/func/socials/getbuiltinservicesdefaults.html
        136.958µs      45.652µs      76.542µs        100        0       0      3  _partials/func/socials/getregisteredservices.html
        125.625µs     125.625µs     125.625µs          0        0       0      1  _shortcodes/leaflet.html
         35.333µs      11.777µs      15.583µs          0        0       0      3  _shortcodes/yellow-button.html
         33.959µs      33.959µs      33.959µs          0        0       0      1  _shortcodes/video.html
          33.71µs       4.213µs       9.833µs        100        0       0      8  _partials/new-window-icon.html
         30.458µs       7.614µs      11.375µs         37        0       0      4  _partials/apdate.html
         10.835µs       1.083µs       2.583µs          0        0       0     10  _shortcodes/rawhtml.html
          8.792µs        2.93µs       3.583µs         33        0       0      3  _partials/apnumber.html
          7.376µs         922ns       1.542µs        100        0       0      8  _partials/svg/new-window.svg
          4.875µs       4.875µs       4.875µs        100        0       0      1  _partials/i18nlist.html
            875ns         875ns         875ns        100        0       0      1  _partials/pwa-nav.html
            833ns         416ns         458ns        100        0       0      2  _partials/newsletter.html
            459ns         459ns         459ns        100        0       0      1  _partials/newsletter-native.html


                  │  EN  
──────────────────┼──────
 Pages            │ 3885 
 Paginator pages  │  245 
 Non-page files   │    0 
 Static files     │ 2250 
 Processed images │    0 
 Aliases          │  323 
 Cleaned          │    0 

Total in 49148 ms\n- Start building sites … 
hugo v0.156.0+extended+withdeploy darwin/arm64 BuildDate=2026-02-18T16:39:55Z VendorInfo=Homebrew


                  │  EN  
──────────────────┼──────
 Pages            │ 3885 
 Paginator pages  │  245 
 Non-page files   │    0 
 Static files     │ 2250 
 Processed images │    0 
 Aliases          │  323 
 Cleaned          │    0 

Total in 51154 ms\n\n## Build impact\n- full build wall time improved from ~58.66s to ~50.02s in local benchmark (~14.7% faster)\n